### PR TITLE
Use ObjectID consructor for queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serve-gridfs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "serve files with mongodb grdifs",
   "main": "build/bundle.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // borrowed from https://github.com/expressjs/serve-static/blob/master/index.js
-import { GridFSBucket } from 'mongodb'
+import { GridFSBucket, ObjectID } from 'mongodb'
 import fresh from 'fresh'
 import parseRange from 'range-parser'
 
@@ -43,7 +43,7 @@ export default function serveGridfs(mongoConnection, options = {}) {
       .then(db => {
         const _id = req.url.substr(1) // removing the first forward slash
         const cursor = db.collection(bucketName + '.files')
-        const findOne = options.byId !== false ? cursor.findOne({ _id }) : cursor.findOne({ filename: _id })
+        const findOne = options.byId !== false ? cursor.findOne({ _id: ObjectID(_id) }) : cursor.findOne({ filename: _id })
         return findOne.then(doc => {
           if (!doc) {
             if (options.fallthrough !== false) {
@@ -88,7 +88,7 @@ export default function serveGridfs(mongoConnection, options = {}) {
             options.byId !== false
               ? 'openDownloadStream'
               : 'openDownloadStreamByName'
-          ](_id, { start, end })
+          ](ObjectID(_id), { start, end })
             .on('error', next)
             .pipe(res)
         })


### PR DESCRIPTION
I had to use `ObjectID` constructor to make your module work properly. Otherwise it could not find any files in case I use searching by _id field (not filename).